### PR TITLE
use github script action to pull the diff

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -18,17 +18,20 @@ jobs:
           fetch-depth: 0
 
       - name: Get the PR diff
-        uses: GrantBirki/git-diff-action@v2.6.0
-        id: git-diff
+        uses: actions/github-script@v7
+        id: diff
         with:
-          raw_diff_file_output: diff.txt
-          file_output_only: "true"
+          result-encoding: string
+          script: |
+            const diff_url = context.payload.pull_request.diff_url
+            const result = await github.request(diff_url)
+            return result.data
 
       - name: Review code
         id: code-review
         run: |
           # Get the diff
-          escaped_diff=$(cat ${{ steps.git-diff.outputs.raw-diff-path }} | jq -sRr @json | sed -e 's/^"//' -e 's/"$//')
+          escaped_diff=$(cat ${{ steps.diff.outputs.raw-diff-path }} | jq -sRr @json | sed -e 's/^"//' -e 's/"$//')
 
           # Send to OpenAI for review
           response=$(curl -X POST https://api.openai.com/v1/chat/completions \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository demonstrates how you can receive code reviews from OpenAI using 
 
 The code review is done by performing the following:
 
-1. Fetch the diff of the pull request using [`GrantBirki/git-diff-action`](https://github.com/GrantBirki/git-diff-action)
+1. Fetch the diff of the pull request
 2. Send the diff to OpenAI for review using the OpenAI API
 3. Capture the response and add it as a comment to the pull request
 


### PR DESCRIPTION
This replaces git-diff-action with github-script which utilizes github's built-in diff tools.